### PR TITLE
chore: list packages and tools installed in gh action runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,7 @@ on:
     paths-ignore:
       - '.github/workflows/gh-pages-publishing.yml'
       - '.github/workflows/gh-pages-status.yml'
+      - '.github/workflows/list-installed-browsers-of-gh-action-runners.yml'
       - '.github/workflows/release-management.yml'
       - 'docs/**'
       - '*.md'
@@ -17,6 +18,7 @@ on:
     paths-ignore:
       - '.github/workflows/gh-pages-publishing.yml'
       - '.github/workflows/gh-pages-status.yml'
+      - '.github/workflows/list-installed-browsers-of-gh-action-runners.yml'
       - '.github/workflows/release-management.yml'
       - 'docs/**'
       - '*.md'

--- a/.github/workflows/list-installed-browsers-of-gh-action-runners.yml
+++ b/.github/workflows/list-installed-browsers-of-gh-action-runners.yml
@@ -14,14 +14,16 @@ jobs:
     steps:
       - name: Ping
         run: echo "I am alive"
+      - name: List installed browsers
+        shell: powershell
+#        run: Get-ItemProperty HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall\* | where DisplayName -Like "*Edge*" | Select-Object DisplayName, DisplayVersion, Publisher, InstallDate | Format-Table -AutoSize
+        run: Get-ItemProperty HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall\* | Where { $_.DisplayName -like "*Chrome*" -or $_.DisplayName -like "*Edge*"} | Select-Object DisplayName, DisplayVersion, Publisher, InstallDate | Format-Table -AutoSize
       - name: List all installed software
         shell: powershell
-        run: Get-ItemProperty HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall\* |  Select-Object DisplayName, DisplayVersion, Publisher, InstallDate | Format-Table -AutoSize
-      - name: List all installed software (alternate query)
-        shell: powershell
-        run: Get-ItemProperty HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall\* |  Format-Table -AutoSize
+        run: Get-ItemProperty HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall\* | Select-Object DisplayName, DisplayVersion, Publisher, InstallDate | Format-Table -AutoSize
 
-## using Get-WmiObject is too slow and has side effects on installed softwares
+
+## using Get-WmiObject is too slow and has side effects on installed software
 #      - name: Check Edge with alternate query
 #        shell: powershell
 #        run: Get-WmiObject -Query "select * from Win32_Product where name='Microsoft Edge'"

--- a/.github/workflows/list-installed-browsers-of-gh-action-runners.yml
+++ b/.github/workflows/list-installed-browsers-of-gh-action-runners.yml
@@ -8,25 +8,6 @@ on:
     paths:
       - '.github/workflows/list-installed-browsers-of-gh-action-runners.yml'
 
-#jobs:
-#  build:
-#    runs-on: ubuntu-latest
-#    steps:
-#      - uses: actions/checkout@v2
-#      - name: Setup node
-#        uses: actions/setup-node@v1
-#        with:
-#          node-version: 12.x
-#      - name: Verify node, npm version
-#        run: |
-#          node --version
-#          npm --version
-#      - name: Install dependencies
-#        run: npm ci
-#      - name: Build Application
-#        run: npm run build
-
-
 #     runs-on: ${{ matrix.os }}
 #    strategy:
 #      # we want to run the full build on all os: don't cancel running jobs even if one fails
@@ -54,18 +35,8 @@ jobs:
         run: Get-WmiObject -Class Win32_Product | where Name -Like "*Chrome*"
 
 
-#  ubuntu_browsers:
-#    runs-on: ${{ matrix.os }}
-#    strategy:
-#      # we want to run the full build on all os: don't cancel running jobs even if one fails
-#      fail-fast: false
-#      matrix:
-#        os: [macos-11, ubuntu-20.04, windows-2019]
-#        browser: [chromium, firefox, chrome]
-#        include:
-#          # only test WebKit on macOS
-#          - os: macos-11
-#            browser: webkit
-#          # only test Edge on Windows
-#          - os: windows-2019
-#            browser: msedge
+  ubuntu_browsers:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check Chrome
+       run: apt show google-chrome-stable

--- a/.github/workflows/list-installed-browsers-of-gh-action-runners.yml
+++ b/.github/workflows/list-installed-browsers-of-gh-action-runners.yml
@@ -1,4 +1,4 @@
-name: Build
+name: List installed browsers
 
 on:
   workflow_dispatch:

--- a/.github/workflows/list-installed-browsers-of-gh-action-runners.yml
+++ b/.github/workflows/list-installed-browsers-of-gh-action-runners.yml
@@ -16,21 +16,28 @@ jobs:
         run: echo "I am alive"
       - name: Check Edge with alternate query
         shell: powershell
-        run: Get-WmiObject -Query "select * from Win32_Product where name='Microsoft Edge'"
-      - name: Check Chrome with alternate query
-        shell: powershell
-        run: Get-WmiObject -Query "select * from Win32_Product where name='Google Chrome'"
+        run: Get-ItemProperty HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall\* |  Select-Object DisplayName, DisplayVersion, Publisher, InstallDate |
+  Format-Table –AutoSize
 
-# use to retrieve the actual name, very slow
-      - name: Check Edge with WmiObject
-        shell: powershell
-        run: Get-WmiObject -Class Win32_Product | where Name -Like "*Edge*"
-#      - name: Check Edge with AppxPackage
+## using Get-WmiObject is too slow and has side effects on installed softwares
+#      - name: Check Edge with alternate query
 #        shell: powershell
-#        run: Get-AppxPackage -Name "Microsoft.MicrosoftEdge.Stable"
-      - name: Check Chrome with WmiObject
-        shell: powershell
-        run: Get-WmiObject -Class Win32_Product | where Name -Like "*Chrome*"
+#        run: Get-WmiObject -Query "select * from Win32_Product where name='Microsoft Edge'"
+#      - name: Check Chrome with alternate query
+#        shell: powershell
+#        run: Get-WmiObject -Query "select * from Win32_Product where name='Google Chrome'"
+#      # Get-WmiObject -Class Win32_Service -Filter "name='WinRM'"
+#
+## use to retrieve the actual name
+#      - name: Check Edge with WmiObject
+#        shell: powershell
+#        run: Get-WmiObject -Class Win32_Product | where Name -Like "*Edge*"
+##      - name: Check Edge with AppxPackage
+##        shell: powershell
+##        run: Get-AppxPackage -Name "Microsoft.MicrosoftEdge.Stable"
+#      - name: Check Chrome with WmiObject
+#        shell: powershell
+#        run: Get-WmiObject -Class Win32_Product | where Name -Like "*Chrome*"
 
 
   ubuntu_browsers:

--- a/.github/workflows/list-installed-browsers-of-gh-action-runners.yml
+++ b/.github/workflows/list-installed-browsers-of-gh-action-runners.yml
@@ -14,12 +14,20 @@ jobs:
     steps:
       - name: Ping
         run: echo "I am alive"
+      - name: Check Edge with alternate query
+        shell: powershell
+        run: Get-WmiObject -Query "select * from Win32_Product where name='Microsoft Edge'"
+      - name: Check Chrome with alternate query
+        shell: powershell
+        run: Get-WmiObject -Query "select * from Win32_Product where name='Google Chrome'"
+
+# use to retrieve the actual name, very slow
       - name: Check Edge with WmiObject
         shell: powershell
         run: Get-WmiObject -Class Win32_Product | where Name -Like "*Edge*"
-      - name: Check Edge with AppxPackage
-        shell: powershell
-        run: Get-AppxPackage -Name "Microsoft.MicrosoftEdge.Stable"
+#      - name: Check Edge with AppxPackage
+#        shell: powershell
+#        run: Get-AppxPackage -Name "Microsoft.MicrosoftEdge.Stable"
       - name: Check Chrome with WmiObject
         shell: powershell
         run: Get-WmiObject -Class Win32_Product | where Name -Like "*Chrome*"

--- a/.github/workflows/list-installed-browsers-of-gh-action-runners.yml
+++ b/.github/workflows/list-installed-browsers-of-gh-action-runners.yml
@@ -14,13 +14,18 @@ jobs:
     steps:
       - name: Ping
         run: echo "I am alive"
-      - name: List installed browsers
+      - name: List installed browsers (64 bits)
         shell: powershell
-#        run: Get-ItemProperty HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall\* | where DisplayName -Like "*Edge*" | Select-Object DisplayName, DisplayVersion, Publisher, InstallDate | Format-Table -AutoSize
         run: Get-ItemProperty HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall\* | Where { $_.DisplayName -like "*Chrome*" -or $_.DisplayName -like "*Edge*"} | Select-Object DisplayName, DisplayVersion, Publisher, InstallDate | Format-Table -AutoSize
-      - name: List all installed software
+      - name: List installed browsers (32/64 bits)
+        shell: powershell
+        run: Get-ItemProperty HKLM:\Software\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\* | Where { $_.DisplayName -like "*Chrome*" -or $_.DisplayName -like "*Edge*"} | Select-Object DisplayName, DisplayVersion, Publisher, InstallDate | Format-Table -AutoSize
+      - name: List all installed software (64 bits)
         shell: powershell
         run: Get-ItemProperty HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall\* | Select-Object DisplayName, DisplayVersion, Publisher, InstallDate | Format-Table -AutoSize
+      - name: List all installed software (32/64 bits)
+        shell: powershell
+        run: Get-ItemProperty HKLM:\Software\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\* | Select-Object DisplayName, DisplayVersion, Publisher, InstallDate | Format-Table -AutoSize
 
 
 ## using Get-WmiObject is too slow and has side effects on installed software

--- a/.github/workflows/list-installed-browsers-of-gh-action-runners.yml
+++ b/.github/workflows/list-installed-browsers-of-gh-action-runners.yml
@@ -1,0 +1,71 @@
+name: Build
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - master
+    paths:
+      - '.github/workflows/list-installed-browsers-of-gh-action-runners.yml'
+
+#jobs:
+#  build:
+#    runs-on: ubuntu-latest
+#    steps:
+#      - uses: actions/checkout@v2
+#      - name: Setup node
+#        uses: actions/setup-node@v1
+#        with:
+#          node-version: 12.x
+#      - name: Verify node, npm version
+#        run: |
+#          node --version
+#          npm --version
+#      - name: Install dependencies
+#        run: npm ci
+#      - name: Build Application
+#        run: npm run build
+
+
+#     runs-on: ${{ matrix.os }}
+#    strategy:
+#      # we want to run the full build on all os: don't cancel running jobs even if one fails
+#      fail-fast: false
+#      matrix:
+#        os: [macos-11, ubuntu-20.04, windows-2019]
+#        browser: [chromium, firefox, chrome]
+#        include:
+#          # only test WebKit on macOS
+#          - os: macos-11
+#            browser: webkit
+#          # only test Edge on Windows
+#          - os: windows-2019
+#            browser: msedge
+
+jobs:
+  windows_browsers:
+    runs-on: windows-2019
+    steps:
+      - name: Check Edge
+        shell: powershell
+        run: Get-WmiObject -Class Win32_Product | where Name -Like "*Edge*"
+      - name: Check Chrome
+        shell: powershell
+        run: Get-WmiObject -Class Win32_Product | where Name -Like "*Chrome*"
+
+
+#  ubuntu_browsers:
+#    runs-on: ${{ matrix.os }}
+#    strategy:
+#      # we want to run the full build on all os: don't cancel running jobs even if one fails
+#      fail-fast: false
+#      matrix:
+#        os: [macos-11, ubuntu-20.04, windows-2019]
+#        browser: [chromium, firefox, chrome]
+#        include:
+#          # only test WebKit on macOS
+#          - os: macos-11
+#            browser: webkit
+#          # only test Edge on Windows
+#          - os: windows-2019
+#            browser: msedge

--- a/.github/workflows/list-installed-browsers-of-gh-action-runners.yml
+++ b/.github/workflows/list-installed-browsers-of-gh-action-runners.yml
@@ -54,3 +54,5 @@ jobs:
     steps:
       - name: Check Chrome
         run: apt show google-chrome-stable
+      - name: List all software
+        run: apt list

--- a/.github/workflows/list-installed-browsers-of-gh-action-runners.yml
+++ b/.github/workflows/list-installed-browsers-of-gh-action-runners.yml
@@ -14,9 +14,12 @@ jobs:
     steps:
       - name: Ping
         run: echo "I am alive"
-      - name: Check Edge with alternate query
+      - name: List all installed software
         shell: powershell
         run: Get-ItemProperty HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall\* |  Select-Object DisplayName, DisplayVersion, Publisher, InstallDate | Format-Table -AutoSize
+      - name: List all installed software (alternate query)
+        shell: powershell
+        run: Get-ItemProperty HKLM:\Software\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\* |  Select-Object DisplayName, DisplayVersion, Publisher, InstallDate | Format-Table -AutoSize
 
 ## using Get-WmiObject is too slow and has side effects on installed softwares
 #      - name: Check Edge with alternate query

--- a/.github/workflows/list-installed-browsers-of-gh-action-runners.yml
+++ b/.github/workflows/list-installed-browsers-of-gh-action-runners.yml
@@ -41,4 +41,4 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Check Chrome
-       run: apt show google-chrome-stable
+        run: apt show google-chrome-stable

--- a/.github/workflows/list-installed-browsers-of-gh-action-runners.yml
+++ b/.github/workflows/list-installed-browsers-of-gh-action-runners.yml
@@ -16,7 +16,7 @@ jobs:
         run: echo "I am alive"
       - name: Check Edge with alternate query
         shell: powershell
-        run: Get-ItemProperty HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall\* |  Select-Object DisplayName, DisplayVersion, Publisher, InstallDate | Format-Table –AutoSize
+        run: Get-ItemProperty HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall\* |  Select-Object DisplayName, DisplayVersion, Publisher, InstallDate | Format-Table -AutoSize
 
 ## using Get-WmiObject is too slow and has side effects on installed softwares
 #      - name: Check Edge with alternate query

--- a/.github/workflows/list-installed-browsers-of-gh-action-runners.yml
+++ b/.github/workflows/list-installed-browsers-of-gh-action-runners.yml
@@ -19,7 +19,7 @@ jobs:
         run: Get-ItemProperty HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall\* |  Select-Object DisplayName, DisplayVersion, Publisher, InstallDate | Format-Table -AutoSize
       - name: List all installed software (alternate query)
         shell: powershell
-        run: Get-ItemProperty HKLM:\Software\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\* |  Select-Object DisplayName, DisplayVersion, Publisher, InstallDate | Format-Table -AutoSize
+        run: Get-ItemProperty HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall\* |  Format-Table -AutoSize
 
 ## using Get-WmiObject is too slow and has side effects on installed softwares
 #      - name: Check Edge with alternate query

--- a/.github/workflows/list-installed-browsers-of-gh-action-runners.yml
+++ b/.github/workflows/list-installed-browsers-of-gh-action-runners.yml
@@ -16,8 +16,7 @@ jobs:
         run: echo "I am alive"
       - name: Check Edge with alternate query
         shell: powershell
-        run: Get-ItemProperty HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall\* |  Select-Object DisplayName, DisplayVersion, Publisher, InstallDate |
-  Format-Table –AutoSize
+        run: Get-ItemProperty HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall\* |  Select-Object DisplayName, DisplayVersion, Publisher, InstallDate | Format-Table –AutoSize
 
 ## using Get-WmiObject is too slow and has side effects on installed softwares
 #      - name: Check Edge with alternate query

--- a/.github/workflows/list-installed-browsers-of-gh-action-runners.yml
+++ b/.github/workflows/list-installed-browsers-of-gh-action-runners.yml
@@ -8,31 +8,19 @@ on:
     paths:
       - '.github/workflows/list-installed-browsers-of-gh-action-runners.yml'
 
-#     runs-on: ${{ matrix.os }}
-#    strategy:
-#      # we want to run the full build on all os: don't cancel running jobs even if one fails
-#      fail-fast: false
-#      matrix:
-#        os: [macos-11, ubuntu-20.04, windows-2019]
-#        browser: [chromium, firefox, chrome]
-#        include:
-#          # only test WebKit on macOS
-#          - os: macos-11
-#            browser: webkit
-#          # only test Edge on Windows
-#          - os: windows-2019
-#            browser: msedge
-
 jobs:
   windows_browsers:
     runs-on: windows-2019
     steps:
       - name: Ping
         run: echo "I am alive"
-      - name: Check Edge
+      - name: Check Edge with WmiObject
         shell: powershell
         run: Get-WmiObject -Class Win32_Product | where Name -Like "*Edge*"
-      - name: Check Chrome
+      - name: Check Edge with AppxPackage
+        shell: powershell
+        run: Get-AppxPackage -Name "Microsoft.MicrosoftEdge.Stable"
+      - name: Check Chrome with WmiObject
         shell: powershell
         run: Get-WmiObject -Class Win32_Product | where Name -Like "*Chrome*"
 

--- a/.github/workflows/list-installed-browsers-of-gh-action-runners.yml
+++ b/.github/workflows/list-installed-browsers-of-gh-action-runners.yml
@@ -27,6 +27,8 @@ jobs:
   windows_browsers:
     runs-on: windows-2019
     steps:
+      - name: Ping
+        run: echo "I am alive"
       - name: Check Edge
         shell: powershell
         run: Get-WmiObject -Class Win32_Product | where Name -Like "*Edge*"


### PR DESCRIPTION
Not covered here: macos

### Resources

Using Get-WmiObject is too slow and has side effects on installed software
Articles used to generate the list on windows 
- https://techcommunity.microsoft.com/t5/enterprise/how-to-check-correct-version-of-edge-chromium/m-p/1978131
- display the google chrome version with powershell: https://stackoverflow.com/a/57618035/14299521
- advice
  - do not use Win32_Product: https://devblogs.microsoft.com/scripting/use-powershell-to-find-installed-software/
  - use the registry instead
    - https://www.codetwo.com/admins-blog/how-to-check-installed-software-version/#local-registry
    - https://devblogs.microsoft.com/scripting/use-powershell-to-quickly-find-installed-software/


