### PR TITLE
ci: simplify build workflow trigger

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,25 +4,27 @@ on:
   push:
     branches:
       - master
-    paths-ignore:
-      - '.github/workflows/gh-pages-publishing.yml'
-      - '.github/workflows/gh-pages-status.yml'
-      - '.github/workflows/list-installed-browsers-of-gh-action-runners.yml'
-      - '.github/workflows/release-management.yml'
-      - 'docs/**'
-      - '*.md'
-      - LICENSE
+    paths:
+      - '.github/workflows/build.yml'
+      - 'public/**/*'
+      - 'src/**/*'
+      - .browserslistrc
+      - .babel.config.js
+      - package.json
+      - package-lock.json
+      - tsconfig.json
   pull_request:
     branches:
       - master
-    paths-ignore:
-      - '.github/workflows/gh-pages-publishing.yml'
-      - '.github/workflows/gh-pages-status.yml'
-      - '.github/workflows/list-installed-browsers-of-gh-action-runners.yml'
-      - '.github/workflows/release-management.yml'
-      - 'docs/**'
-      - '*.md'
-      - LICENSE
+    paths:
+      - '.github/workflows/build.yml'
+      - 'public/**/*'
+      - 'src/**/*'
+      - .browserslistrc
+      - .babel.config.js
+      - package.json
+      - package-lock.json
+      - tsconfig.json
 
 jobs:
   build:

--- a/.github/workflows/check-pr-cc.yml
+++ b/.github/workflows/check-pr-cc.yml
@@ -12,4 +12,4 @@ jobs:
       pull-requests: write # post comments when the PR title doesn't match the "Conventional Commits" rules
     steps:
       - name: Check Pull Request title
-        uses: bonitasoft/actions/packages/pr-title-conventional-commits@TAGNAME
+        uses: bonitasoft/actions/packages/pr-title-conventional-commits@v2


### PR DESCRIPTION
Use `paths` instead of `paths-ignore` to simplify the maintenance. We were previously forced to list new added file and we often forgot to do it.